### PR TITLE
chore!: replace uchileedxlogin by eol_sso

### DIFF
--- a/eolreportcertificate/tests.py
+++ b/eolreportcertificate/tests.py
@@ -125,32 +125,32 @@ class TestEolReportCertificateView(ModuleStoreTestCase):
         request = response.request
         self.assertEqual(response.status_code, 405)
 
-    @patch('eolreportcertificate.views.get_user_id_doc_id_pairs')
-    def test_get_enrolled_users_with_doc_id(self, mock_user_id_doc_id_pair):
+    @patch('eolreportcertificate.views.get_user_id_with_indiv_id_list')
+    def test_get_enrolled_users_with_indiv_id(self, mock_user_id_with_indiv_id_list):
         """
-        Test get_all_enrolled_users when the users have a doc_id associated with them.
+        Test get_all_enrolled_users when the users have a indiv_id associated with them.
         """
-        mock_user_id_doc_id_pair.return_value = [(self.student.id, '1234567K'), (self.student_2.id, '12345678')]
+        mock_user_id_with_indiv_id_list.return_value = [(self.student.id, '1234567K'), (self.student_2.id, '12345678')]
         enrolled_users = EolReportCertificateView().get_all_enrolled_users(self.course.id, 'this_is_a_url')
         self.assertEqual(enrolled_users[0][1], '1234567K')
         self.assertEqual(enrolled_users[1][1], '12345678')
 
-    @patch('eolreportcertificate.views.get_user_id_doc_id_pairs')
-    def test_get_enrolled_users_without_doc_id(self, mock_user_id_doc_id_pair):
+    @patch('eolreportcertificate.views.get_user_id_with_indiv_id_list')
+    def test_get_enrolled_users_without_indiv_id(self, mock_user_id_with_indiv_id_list):
         """
-        Test get_all_enrolled_users when the users doesn't have a doc_id associated with them.
+        Test get_all_enrolled_users when the users doesn't have a indiv_id associated with them.
         """
-        mock_user_id_doc_id_pair.return_value = []
+        mock_user_id_with_indiv_id_list.return_value = []
         enrolled_users = EolReportCertificateView().get_all_enrolled_users(self.course.id, 'this_is_a_url')
         self.assertEqual(enrolled_users[0][1], '')
         self.assertEqual(enrolled_users[1][1], '')
 
-    @patch('eolreportcertificate.views.get_user_id_doc_id_pairs')
-    def test_eolreportcertificate_get(self, mock_user_id_doc_id_pair):
+    @patch('eolreportcertificate.views.get_user_id_with_indiv_id_list')
+    def test_eolreportcertificate_get(self, mock_user_id_with_indiv_id_list):
         """
             Test eolreportcertificate get normal process
         """
-        mock_user_id_doc_id_pair.return_value = [(self.student.id, '09472337K')]
+        mock_user_id_with_indiv_id_list.return_value = [(self.student.id, '09472337K')]
         task_input = {'base_url': 'this_is_a_url'}
         with patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task'):
             result = task_get_data(

--- a/eolreportcertificate/views.py
+++ b/eolreportcertificate/views.py
@@ -18,7 +18,7 @@ from django.urls import reverse
 from django.utils.translation import ugettext_noop
 from django.views.generic.base import View
 from pytz import UTC
-from uchileedxlogin.services.interface import get_user_id_doc_id_pairs
+from eol_sso.services.interface import get_user_id_with_indiv_id_list
 import six
 
 # Edx dependencies
@@ -158,13 +158,13 @@ class EolReportCertificateView(View):
             generatedcertificate__course_id=course_key
         ).order_by('username').values('id', 'username', 'email', 'generatedcertificate__verify_uuid', 'generatedcertificate__mode')
         user_id_list = enrolled_students.values_list('id', flat=True)
-        user_doc_id = get_user_id_doc_id_pairs(user_id_list)
-        user_doc_id_dict = {id: doc_id for id, doc_id in user_doc_id}
+        user_indiv_id_list = get_user_id_with_indiv_id_list(user_id_list)
+        user_indiv_id_dict = {id: indiv_id for id, indiv_id in user_indiv_id_list}
         for user in enrolled_students:
-            user['doc_id'] = user_doc_id_dict.get(user['id'], '')
+            user['indiv_id'] = user_indiv_id_dict.get(user['id'], '')
             students.append([
                 user['username'],                
-                user['doc_id'],
+                user['indiv_id'],
                 user['email'],
                 user['generatedcertificate__mode'],
                 '{}{}'.format(base_url, reverse('certificates:render_cert_by_uuid', kwargs={'certificate_uuid':user['generatedcertificate__verify_uuid']}))])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,5 @@
-autopep8==1.4.4
-certifi==2019.9.11
-chardet==3.0.4
-Django==1.11.29
-edx-opaque-keys==2.0.0
-funcsigs==1.0.2
-idna==2.8
-mock==3.0.5
-pbr==5.4.4
-pycodestyle==2.5.0
-pymongo==3.9.0
 pytz==2019.3
 requests==2.22.0
 six==1.13.0
-stevedore==1.31.0
 Unidecode==1.1.1
-urllib3==1.25.6
+-e git+https://github.com/eol-uchile/eol_sso@1.0.1#egg=eol_sso

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="eolreportcertificate",
-    version="1.1.0",
+    version="2.0.0",
     author="Oficina EOL UChile",
     author_email="eol-ing@uchile.cl",
     description="Allows you to download a csv of Certificates Issued",

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,1 +1,2 @@
 -e git+https://github.com/eol-uchile/uchileedxlogin@1.0.0#egg=uchileedxlogin
+-e git+https://github.com/eol-uchile/eol_sso@1.0.1#egg=eol_sso


### PR DESCRIPTION
Se actualiza eol_report_certificate para utilizar eol_sso en vez de uchileedxlogin.
Se reemplazan las menciones de doc_id por indiv_id.
Se actualizan los tests y sus requirements.
Se borran los requirements no utilizados en requirements.txt